### PR TITLE
feat(ci): Add Claude code review automation workflow

### DIFF
--- a/.github/workflows/claude-manual-review.yml
+++ b/.github/workflows/claude-manual-review.yml
@@ -1,0 +1,25 @@
+name: Request Claude Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
+
+jobs:
+  prepare-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get PR diff
+        run: |
+          gh pr diff ${{ inputs.pr_number }} > pr_diff.txt
+          echo "📋 PR #${{ inputs.pr_number }} diff saved to pr_diff.txt"
+          echo "👉 Copy this diff to Claude for review"
+          echo "🔗 PR URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ inputs.pr_number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,56 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR diff
+        id: diff
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD > pr_diff.txt
+          echo "diff_size=$(wc -l < pr_diff.txt)" >> $GITHUB_OUTPUT
+
+      - name: Claude Review
+        if: steps.diff.outputs.diff_size < 500
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const diff = fs.readFileSync('pr_diff.txt', 'utf8');
+            
+            // For now, create a comment requesting Claude review
+            const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`;
+            const reviewRequest = `## 🤖 Claude Review Requested
+            
+            This PR is ready for Claude Code review!
+            
+            **Review checklist:**
+            - [ ] Code quality and best practices
+            - [ ] TypeScript type safety
+            - [ ] React patterns and performance
+            - [ ] Test coverage and quality
+            - [ ] Documentation completeness
+            
+            **Diff size:** ${fs.readFileSync('pr_diff.txt', 'utf8').split('\n').length} lines
+            
+            _🏷️ Tagged with: \`claude-assisted\`_`;
+            
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: reviewRequest
+            });


### PR DESCRIPTION
## Summary
- Add automated Claude review request workflow that triggers on PR creation
- Include manual workflow for on-demand Claude reviews
- Integrate with existing `claude-assisted` labeling system

## Features Added
- **Automated comments** on PRs requesting Claude review with structured checklist
- **Manual trigger workflow** for selective review requests  
- **Review checklist** covering code quality, TypeScript, React patterns, tests, and docs
- **Diff size tracking** to manage review scope

## Test plan
- [x] Workflow files created with proper GitHub Actions syntax
- [x] Permissions configured for PR comments and content access
- [x] Integration with existing claude-assisted labeling workflow
- [ ] Test automated comment creation on new PR
- [ ] Test manual workflow trigger functionality

## Technical Details
- Uses `actions/github-script@v7` for comment creation
- Triggers on `pull_request: [opened, synchronize]` events
- Includes size limits to manage review scope (< 500 lines)
- Manual workflow accepts PR number input for targeted reviews