### PR TITLE
chore: integrate ESLint with Prettier for consistent code formatting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
+import prettierConfig from 'eslint-config-prettier'
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -14,6 +15,7 @@ export default tseslint.config([
       tseslint.configs.recommended,
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
+      prettierConfig, // This must be last to override ESLint formatting rules
     ],
     languageOptions: {
       ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/ui": "^3.2.4",
         "eslint": "^9.30.1",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
@@ -3615,6 +3616,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/ui": "^3.2.4",
     "eslint": "^9.30.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",


### PR DESCRIPTION
## Summary
Integrate ESLint with Prettier to ensure consistent code formatting without conflicts between the two tools.

## Changes
- ✅ Install `eslint-config-prettier` as a dev dependency
- ✅ Update ESLint configuration to extend `prettierConfig` at the end of the configuration chain
- ✅ Ensure proper separation of concerns: ESLint for code quality, Prettier for formatting

## Why This Matters
Previously, ESLint and Prettier could have conflicting rules about formatting (semicolons, quotes, spacing, etc.). This integration:
- Disables all ESLint formatting rules that conflict with Prettier
- Lets Prettier handle all formatting decisions
- Keeps ESLint focused on code quality (unused variables, React hooks, TypeScript issues)

## Configuration Details
```javascript
// ESLint now extends prettierConfig last to override formatting rules
extends: [
  js.configs.recommended,
  tseslint.configs.recommended,
  reactHooks.configs['recommended-latest'],
  reactRefresh.configs.vite,
  prettierConfig, // Must be last
]
```

## Test Plan
- [x] Verify ESLint no longer complains about Prettier formatting
- [x] Confirm format-on-save works correctly in VSCode
- [x] Ensure `npm run lint` focuses only on code quality issues
- [x] Verify no formatting conflicts between tools

## Related
- VSCode settings already configured with `editor.defaultFormatter: "esbenp.prettier-vscode"`
- Format on save enabled for all relevant file types