### PR TITLE
Remove unused filter performance tracking

### DIFF
--- a/src/components/RecommendationFilters/RecommendationFilters.test.tsx
+++ b/src/components/RecommendationFilters/RecommendationFilters.test.tsx
@@ -31,7 +31,6 @@ const mockFilters: UseFiltersReturn = {
     appliedFilters: [],
     searchQuery: '',
     totalMatches: 0,
-    executionTime: 10.5,
   },
   isLoading: false,
   error: null,
@@ -44,22 +43,6 @@ const mockFilters: UseFiltersReturn = {
     updatePagination: vi.fn(),
     resetFilters: vi.fn(),
   },
-  metrics: [
-    {
-      filterType: 'search',
-      itemCount: 17,
-      executionTime: 8.2,
-      matchCount: 17,
-      timestamp: new Date('2023-07-01T10:00:00.000Z'),
-    },
-    {
-      filterType: 'skill',
-      itemCount: 17,
-      executionTime: 12.1,
-      matchCount: 5,
-      timestamp: new Date('2023-07-01T10:01:00.000Z'),
-    },
-  ],
 };
 
 describe('RecommendationFilters', () => {

--- a/src/hooks/useRecommendationFilters.test.ts
+++ b/src/hooks/useRecommendationFilters.test.ts
@@ -1,13 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { useRecommendationFilters } from './useRecommendationFilters';
 import type { Recommendation } from '../data/recommendations';
 import type { SkillFilter } from '../types/filtering';
-
-// Mock performance.now for consistent testing
-beforeEach(() => {
-  vi.spyOn(performance, 'now').mockReturnValue(100);
-});
 
 // Mock data for testing
 const mockRecommendations: Recommendation[] = [
@@ -329,30 +324,6 @@ describe('useRecommendationFilters', () => {
       });
       
       expect(result.current.results.pagination.currentPage).toBe(1);
-    });
-  });
-
-  describe('performance tracking', () => {
-    it('should track performance metrics', () => {
-      const { result } = renderHook(() => useRecommendationFilters(mockRecommendations));
-      
-      expect(result.current.results.executionTime).toBeGreaterThanOrEqual(0);
-      expect(result.current.metrics.length).toBeGreaterThan(0);
-      expect(result.current.metrics[result.current.metrics.length - 1]!.filterType).toBe('search');
-      expect(result.current.metrics[result.current.metrics.length - 1]!.itemCount).toBe(3);
-    });
-
-    it('should track metrics for different operations', () => {
-      const { result } = renderHook(() => useRecommendationFilters(mockRecommendations));
-      const initialMetricsCount = result.current.metrics.length;
-      
-      act(() => {
-        result.current.actions.updateSearch('React');
-      });
-      
-      expect(result.current.metrics.length).toBeGreaterThan(initialMetricsCount);
-      const latestMetric = result.current.metrics[result.current.metrics.length - 1];
-      expect(latestMetric!.matchCount).toBe(1);
     });
   });
 

--- a/src/types/filtering.ts
+++ b/src/types/filtering.ts
@@ -94,7 +94,6 @@ export interface FilterResult {
   readonly appliedFilters: readonly Filter[];
   readonly searchQuery: string;
   readonly totalMatches: number;
-  readonly executionTime: number; // in milliseconds for performance tracking
 }
 
 // Advanced filter predicates for complex filtering logic
@@ -108,15 +107,6 @@ export interface FilterPredicateConfig {
   readonly dateRange: FilterPredicate;
 }
 
-// Filter performance tracking
-export interface FilterPerformanceMetrics {
-  readonly filterType: Filter['type'] | 'search';
-  readonly itemCount: number;
-  readonly executionTime: number;
-  readonly matchCount: number;
-  readonly timestamp: Date;
-}
-
 // Hook interfaces for type-safe state management
 export interface UseFiltersReturn {
   readonly filters: FilterState;
@@ -124,7 +114,6 @@ export interface UseFiltersReturn {
   readonly isLoading: boolean;
   readonly error: Error | null;
   readonly actions: FilterActions;
-  readonly metrics: FilterPerformanceMetrics[];
 }
 
 export interface FilterActions {


### PR DESCRIPTION
## Summary
- Removed performance metrics collection from recommendation filters
- Simplified filtering implementation by removing unnecessary state management
- Cleaned up related test suites

## Changes
- **Removed types**: `FilterPerformanceMetrics` interface and related type definitions
- **Removed state**: `performanceMetrics` state and `trackPerformance` callback function
- **Removed tracking**: `executionTime` tracking from filter results
- **Updated tests**: Removed performance-related test assertions and mocks
- **Simplified hook**: Cleaner `useRecommendationFilters` implementation without metrics overhead

## Motivation
The performance metrics were being collected but never displayed or utilized in the application. Removing this unused code reduces complexity and improves maintainability.

## Test Plan
- [x] All existing filter functionality tests pass
- [x] Filter operations work correctly in the UI
- [x] No performance regressions observed